### PR TITLE
📃 docs: Fix some typos in README

### DIFF
--- a/asset/ExpresswayA/README.md
+++ b/asset/ExpresswayA/README.md
@@ -1,7 +1,7 @@
 ### Freeway A (Weaving Segment) 
 ##### Sample Data: [Google Drive Link](https://drive.google.com/drive/folders/1t0RNw0I3k06rPchSvgkQvzKU_2P-mbhV?usp=sharing) | [Baidu Yun Link]( https://pan.baidu.com/s/1mF423Onhbgt7wVZdyxOqvA?pwd=r6f5 ))
 
-:white_check_mark: 120 Mintues Trajectory
+:white_check_mark: 120 Minutes Trajectory
 
 :white_check_mark:  Carla Base Map
 

--- a/asset/FreewayB/README.md
+++ b/asset/FreewayB/README.md
@@ -2,7 +2,7 @@
 
 ##### Sample Data [Google Drive Link](https://drive.google.com/drive/folders/1wVRBDhHkSRNDrqEEEwQft3qKWCbaBDxh?usp=sharing) | [Baidu Yun Link](https://pan.baidu.com/s/1Dq64PNY6OS1WfABDhkKvMA?pwd=csja))
 
-:white_check_mark:  60 Mintues Trajectory
+:white_check_mark:  60 Minutes Trajectory
 
 :white_check_mark:  Carla Base Map
 

--- a/asset/FreewayC/README.md
+++ b/asset/FreewayC/README.md
@@ -2,9 +2,9 @@
 
 ##### Sample Data: [Google Drive Link](https://drive.google.com/drive/folders/1BbOfB86a1Lzef8rTHWzd6a_jvruJIH2L?usp=sharing) | [Baidu Yun Link](https://pan.baidu.com/s/1eTrq0OTsubOAi7v9kLzCEQ?pwd=o331))
 
-:white_check_mark:  60 Mintues Trajectory
+:white_check_mark:  60 Minutes Trajectory
 
-:white_check_mark:  60 Mintues Signal Timing
+:white_check_mark:  60 Minutes Signal Timing
 
 :white_check_mark:  Carla Base Map
 

--- a/asset/GarageC/README.md
+++ b/asset/GarageC/README.md
@@ -1,9 +1,9 @@
 ### UCF Garage C (Consecutive Signalized Intersections)
 ##### Sample Data [Google Drive Link](https://drive.google.com/drive/folders/1m4eIq4dcbx5olBazagOXqvM6KBgXeCaT?usp=sharing) | [Baidu Yun Link]( https://pan.baidu.com/s/1M-MEC-DeHsBMW9OpltEwbQ?pwd=8eek)
 
-:white_check_mark: 15 Mintues Trajectory
+:white_check_mark: 15 Minutes Trajectory
 
-:white_check_mark: 15 Mintues Signal Timing
+:white_check_mark: 15 Minutes Signal Timing
 
 :white_check_mark: Carla Base Map
 

--- a/asset/McCulloch@Seminole /README.md
+++ b/asset/McCulloch@Seminole /README.md
@@ -1,7 +1,7 @@
 ### McCulloch @ Seminole (Non-Signalized Intersection) 
 ##### Sample Data [Google Drive Link](https://drive.google.com/drive/folders/1DOPb_EqEwqPwFKlqL9XWoVZrJOqjsntE?usp=sharing) | [Baidu Yun Link]( https://pan.baidu.com/s/1rGTsQJwH-5LyT8I5GwtLCA?pwd=6ujc)
 
-:white_check_mark: 60 Mintues Trajectory
+:white_check_mark: 60 Minutes Trajectory
 
 :white_check_mark: Carla Base Map
 

--- a/asset/UCFGym/README.md
+++ b/asset/UCFGym/README.md
@@ -1,6 +1,6 @@
 ### Freeway A (Weaving Segment) (Sample Data TBA)
 
-:white_check_mark: 120 Mintues Trajectory
+:white_check_mark: 120 Minutes Trajectory
 
 :white_check_mark:  Carla Base Map
 

--- a/asset/University@Alafaya/README.md
+++ b/asset/University@Alafaya/README.md
@@ -1,8 +1,8 @@
 ### University @ Alafaya (Signalized Intersection) 
 ##### Sample Data [Google Drive Link](https://drive.google.com/drive/folders/1fHzmDxPHHofIBzQpx75Aol9pYCMX9gx7?usp=sharing) | [Baidu Yun Link](https://pan.baidu.com/s/1M6M7RlDwBUC-VoYVpcwpBQ?pwd=tfde)
-:white_check_mark:  60 Mintues Trajectory
+:white_check_mark:  60 Minutes Trajectory
 
-:white_check_mark:  60 Mintues Signal Timing
+:white_check_mark:  60 Minutes Signal Timing
 
 :white_check_mark:  Carla Base Map
 

--- a/asset/University@McCulloch/README.md
+++ b/asset/University@McCulloch/README.md
@@ -1,6 +1,6 @@
 # University@McCulloch
 
-:white_check_mark: 60 Mintues Trajectory
+:white_check_mark: 60 Minutes Trajectory
 
 :white_check_mark: Carla Base Map
 


### PR DESCRIPTION
There is a typo in the readme, where _Minutes_ is typed as _Mintues_.